### PR TITLE
Make entire QRcode area clickable

### DIFF
--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -383,6 +383,7 @@ body,
 
   position: absolute;
   right: 10px;
+  pointer-events: none;
 }
 
 .logo {


### PR DESCRIPTION
The text and SVG were capturing / blocking the click event on the parent container. This should fix that. 